### PR TITLE
Remove autodecte menurole

### DIFF
--- a/apply.bat
+++ b/apply.bat
@@ -28,6 +28,8 @@ cd qtbase
 "C:\Program Files\Git\usr\bin\patch.exe" -p1 < 0206-preallocate-formatChanges-also-for-whole-block-lengt.patch
 "C:\Program Files\Git\usr\bin\patch.exe" -p1 < 0207-always-show-tooltip-for-QTabBar-TP-21494.patch
 "C:\Program Files\Git\usr\bin\patch.exe" -p1 < 0208-add-white-space-color.patch
+"C:\Program Files\Git\usr\bin\patch.exe" -p1 < 0209_preferences.patch
+"C:\Program Files\Git\usr\bin\patch.exe" -p1 < 0210_disable_autodetect_menurole.patch
 cd ..
 
 cd qtdeclarative

--- a/apply.sh
+++ b/apply.sh
@@ -31,6 +31,8 @@ patch -p1 < 0204-show-LTR-and-RTL-bidi-operators.patch
 patch -p1 < 0206-preallocate-formatChanges-also-for-whole-block-lengt.patch
 patch -p1 < 0207-always-show-tooltip-for-QTabBar-TP-21494.patch
 patch -p1 < 0208-add-white-space-color.patch
+patch -p1 < 0209_preferences.patch
+patch -p1 < 0210_disable_autodetect_menurole.patch
 
 patch -p1 --forward < 1000-cast_types_for_egl_x11_test.diff
 cd ..

--- a/qtbase/0210_disable_autodetect_menurole.patch
+++ b/qtbase/0210_disable_autodetect_menurole.patch
@@ -1,0 +1,18 @@
+diff --git a/src/plugins/platforms/cocoa/qcocoamenuitem.mm b/src/plugins/platforms/cocoa/qcocoamenuitem.mm
+index 258aee82a5..34fe12017b 100644
+--- a/src/plugins/platforms/cocoa/qcocoamenuitem.mm
++++ b/src/plugins/platforms/cocoa/qcocoamenuitem.mm
+@@ -302,11 +310,8 @@ NSUInteger keySequenceModifierMask(const QKeySequence &accel)
+                 QCocoaMenuObject *menuObject = dynamic_cast<QCocoaMenuObject *>(p);
+                 p = menuObject ? menuObject->menuParent() : nullptr;
+             }
+-
+-            if (menubar && depth < 3)
+-                m_detectedRole = detectMenuRole(m_text);
+-            else
+-                m_detectedRole = NoRole;
++            // no autodetection of roles
++            m_detectedRole = NoRole;
+         }
+ 
+         QCocoaMenuLoader *loader = [QCocoaMenuLoader sharedMenuLoader];


### PR DESCRIPTION
This modification allows to skip Qt autodetection of menu roles and relies only on provided roles.