### PR TITLE
allow control about whitespace escape

### DIFF
--- a/qtbase/0115-always-escape-whitespace-characters-to-keep-newlines.patch
+++ b/qtbase/0115-always-escape-whitespace-characters-to-keep-newlines.patch
@@ -1,27 +1,31 @@
-From bae00149d41ff22a5dca18b879eb31f546c2f87e Mon Sep 17 00:00:00 2001
-From: Michal Lazo <michal.lazo@memsource.com>
-Date: Wed, 7 Apr 2021 15:29:24 +0200
-Subject: [PATCH] always escape whitespace characters to keep newlines and
- carriage return TP-47747
-
-Change-Id: I2c9212522e621cd948a8b2ce728fe7cfc22bffa6
----
- src/corelib/serialization/qxmlstream.cpp | 2 +-
- 1 file changed, 1 insertion(+), 1 deletion(-)
-
 diff --git a/src/corelib/serialization/qxmlstream.cpp b/src/corelib/serialization/qxmlstream.cpp
-index abbd5999ef..7b73022687 100644
+index 9b595000e6..8702474160 100644
 --- a/src/corelib/serialization/qxmlstream.cpp
 +++ b/src/corelib/serialization/qxmlstream.cpp
-@@ -3628,7 +3628,7 @@ void QXmlStreamWriter::writeCharacters(const QString &text)
+@@ -3435,11 +3435,11 @@ void QXmlStreamWriter::writeCDATA(QAnyStringView text)
+   \note In Qt versions prior to 6.5, this function took QString, not
+   QAnyStringView.
+  */
+-void QXmlStreamWriter::writeCharacters(QAnyStringView text)
++void QXmlStreamWriter::writeCharacters(QAnyStringView text, bool escapeWhitespaces )
  {
      Q_D(QXmlStreamWriter);
      d->finishStartElement();
 -    d->writeEscaped(text);
-+    d->writeEscaped(text, true);
++    d->writeEscaped(text, escapeWhitespaces );
  }
  
  
--- 
-2.26.1.windows.1
-
+diff --git a/src/corelib/serialization/qxmlstream.h b/src/corelib/serialization/qxmlstream.h
+index fffb9b689c..10d0c1c080 100644
+--- a/src/corelib/serialization/qxmlstream.h
++++ b/src/corelib/serialization/qxmlstream.h
+@@ -363,7 +363,7 @@ public:
+     void writeTextElement(const QString &namespaceUri, const QString &name, const QString &text);
+ #endif
+     void writeCDATA(QAnyStringView text);
+-    void writeCharacters(QAnyStringView text);
++    void writeCharacters(QAnyStringView text, bool escapeWhitespaces = false);
+     void writeComment(QAnyStringView text);
+ 
+     void writeDTD(QAnyStringView dtd);


### PR DESCRIPTION
Michal forced Qt to always escape white chars. 

It might actually be more usefull to have control on when to escape. 
It seems that there are situations when we might need escape and not escape them.

We can either never escape them and have full control in our code. 
Or we can at least allow us to change the behaviour in exceptional cases like subtitle files where a mix of `\n` and `\r` seems to be needed.